### PR TITLE
Responding to Nimisha's important comments

### DIFF
--- a/review/configuration.py
+++ b/review/configuration.py
@@ -35,4 +35,4 @@ ENROLLMENT_COURSE_MAPPING = {
     # Anant's course
     'course-v1:MITx+6.002.3x+2T2016': 'course-v1:MITx+6.002.3x_review+2T2016',
 }
-TEMPLATE_URL = settings.LMS_ROOT_URL + '/xblock/block-v1:{course_id}+type@{type}+block@{xblock_id}'
+XBLOCK_VIEW_URL_TEMPLATE = settings.LMS_ROOT_URL + '/xblock/block-v1:{course_id}+type@{type}+block@{xblock_id}'

--- a/review/get_review_ids.py
+++ b/review/get_review_ids.py
@@ -20,9 +20,10 @@ import pytz
 from courseware.models import StudentModule
 from enrollment.api import add_enrollment, get_enrollment, update_enrollment
 from lms.djangoapps.course_blocks.api import get_course_blocks
+from lms.djangoapps.grades.transformer import GradesTransformer
 from xmodule.modulestore.django import modulestore
 
-from .configuration import ENROLLMENT_COURSE_MAPPING, REVIEW_COURSE_MAPPING, TEMPLATE_URL
+from .configuration import ENROLLMENT_COURSE_MAPPING, REVIEW_COURSE_MAPPING, XBLOCK_VIEW_URL_TEMPLATE
 
 log = logging.getLogger(__name__)
 
@@ -43,13 +44,17 @@ def get_problems(num_desired, current_course):
     '''
     user = crum.get_current_user()
 
-    enroll_user_in_review_course(user, current_course)
+    enroll_user_in_review_course_if_needed(user, current_course)
+
     store = modulestore()
+    course_usage_key = store.make_course_usage_key(current_course)
+    course_blocks = get_course_blocks(user, course_usage_key)
 
     problem_data = []
 
     for block_key, state in get_records(user, current_course):
-        if is_valid_problem(store, block_key, state):
+        block_key = block_key.replace(course_key=store.fill_in_run(block_key.course_key))
+        if is_valid_problem(store, block_key, state, course_blocks):
             correct, attempts = get_correctness_and_attempts(state)
             problem_id = block_key.block_id
             problem_data.append((problem_id, correct, attempts))
@@ -62,7 +67,7 @@ def get_problems(num_desired, current_course):
     review_course_id = REVIEW_COURSE_MAPPING[str(current_course)]
     problem_information = []
     for problem, correct, attempts in problems_to_show:
-        problem_information.append((TEMPLATE_URL.format(course_id=review_course_id,
+        problem_information.append((XBLOCK_VIEW_URL_TEMPLATE.format(course_id=review_course_id,
                                     type='problem', xblock_id=problem), correct, attempts))
     return problem_information
 
@@ -80,7 +85,7 @@ def get_vertical(current_course):
     '''
     user = crum.get_current_user()
 
-    enroll_user_in_review_course(user, current_course)
+    enroll_user_in_review_course_if_needed(user, current_course)
 
     store = modulestore()
     course_usage_key = store.make_course_usage_key(current_course)
@@ -89,19 +94,48 @@ def get_vertical(current_course):
     vertical_data = set()
 
     for block_key, state in get_records(user, current_course):
-        if is_valid_problem(store, block_key, state):
-            parent = course_blocks.get_parents(block_key)[0]
-            vertical_id = parent.block_id
-            vertical_data.add(vertical_id)
-            delete_state_of_review_problem(user, current_course, block_key.block_id)
+        block_key = block_key.replace(course_key=store.fill_in_run(block_key.course_key))
+        if is_valid_problem(store, block_key, state, course_blocks):
+            # If the block_key does not have a subsection (sequential) in it's tree,
+            # we should skip it.
+            subsection = course_blocks.get_transformer_block_field(
+                block_key,
+                GradesTransformer,
+                'subsections',
+                set(),
+            )
+            if subsection:
+                try:
+                    vertical = course_blocks.get_parents(block_key)[0]
+                    sequential = course_blocks.get_parents(vertical)[0]
+                    # This is in case the direct parent of a problem is not a vertical,
+                    # we want to keep looking until we find the parent vertical to display.
+                    # For example, you may see:
+                    # sequential -> vertical -> split_test -> problem
+                    # OR
+                    # sequential -> vertical -> vertical -> problem
+                    # OR
+                    # sequential -> vertical -> conditional_block -> problem
+                    while sequential.block_type != 'sequential' and vertical.block_type != 'vertical':
+                        vertical = sequential
+                        sequential = course_blocks.get_parents(vertical)[0]
+                # Catches IndexError for the case where the parent we are looking for
+                # is not the first element returned in get_parents. This can lead to
+                # looking in a part of the tree that does not include what we want. In
+                # this case, we will just skip the problem.
+                except IndexError:
+                    continue
+
+                vertical_data.add(vertical.block_id)
+                delete_state_of_review_problem(user, current_course, block_key.block_id)
 
     if not vertical_data:
         return []
 
     vertical_to_show = random.sample(vertical_data, 1)[0]
     review_course_id = REVIEW_COURSE_MAPPING[str(current_course)]
-    return (TEMPLATE_URL.format(course_id=review_course_id,
-                                type='vertical', xblock_id=vertical_to_show))
+    return (XBLOCK_VIEW_URL_TEMPLATE.format(course_id=review_course_id,
+                                            type='vertical', xblock_id=vertical_to_show))
 
 
 def get_records(user, current_course):
@@ -130,7 +164,7 @@ def get_records(user, current_course):
             yield record.module_state_key, state
 
 
-def enroll_user_in_review_course(user, current_course):
+def enroll_user_in_review_course_if_needed(user, current_course):
     '''
     If the user is not enrolled in the review version of the course,
     they are unable to see any of the problems. This ensures they
@@ -197,13 +231,18 @@ def get_correctness_and_attempts(state):
     return (correct, attempts)
 
 
-def is_valid_problem(store, block_key, state):
+def is_valid_problem(store, block_key, state, course_blocks):
     '''
     Checks a problem to see if it is valid to show to the learner. The
     reason to have this is so learners don't try to cheat by using the
     review problems to find out the correct answer and then using it to
     answer the actual problem.
-    Conditions to be valid:
+
+    Required condition to be valid:
+        The problem is accessible to the learner (checked through the block
+            structure in the course)
+
+    Possible conditions to be valid (at least 1 must be true):
         1) Ungraded (it's ungraded originally so showing it again is okay)
         2) Correctly answered (the learner has already correctly answered
             the problem so it should be fine to show them again.)
@@ -219,6 +258,9 @@ def is_valid_problem(store, block_key, state):
 
     Returns True if the problem is valid, False otherwise
     '''
+    if block_key not in course_blocks:
+        return False
+
     problem = store.get_item(block_key)
     if not problem.graded:
         return True
@@ -232,4 +274,5 @@ def is_valid_problem(store, block_key, state):
         now = now.replace(tzinfo=pytz.utc)
         if now > problem.due:
             return True
+
     return False

--- a/review/templates/review.html
+++ b/review/templates/review.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<h3 class="hd hd-2">{% trans "Review Component" as msg %}{{ msg | force_escape }}</h3>
+<h3 class="hd hd-2">{% trans "Review Problems" as msg %}{{ msg | force_escape }}</h3>
 <p>
   {% filter force_escape %}
     {% blocktrans %}

--- a/review/translations/README.txt
+++ b/review/translations/README.txt
@@ -1,4 +1,0 @@
-Use this translations directory to provide internationalized strings for your XBlock project.
-
-For more information on how to enable translations, visit the Open edX XBlock tutorial on Internationalization:
-http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/edx_platform/edx_lms.html

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ long_description = open(os.path.join(os.path.dirname(__file__), 'README.rst')).r
 
 setup(
     name='xblock-review',
-    version='1.0.1',
+    version='1.1.0',
     description='The Review XBlock is designed to act as a review tool for learners in their edX course.',
     long_description = long_description,
     license='AGPL v3',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ long_description = open(os.path.join(os.path.dirname(__file__), 'README.rst')).r
 
 setup(
     name='xblock-review',
-    version='1.0.0',
+    version='1.0.1',
     description='The Review XBlock is designed to act as a review tool for learners in their edX course.',
     long_description = long_description,
     license='AGPL v3',
@@ -42,5 +42,5 @@ setup(
             'review = review:ReviewXBlock',
         ]
     },
-    package_data=package_data('review', ['static', 'public']),
+    package_data=package_data('review', ['static', 'templates']),
 )


### PR DESCRIPTION
@nasthagiri Please review the changes I made to address your "**Important**" comments. I have not double checked everything works yet, but will be doing that tomorrow morning (and will update this comment once I have). And my apologies for it being in a new PR and not being able to see your comments in line, I merged the last PR before I saw any of your comments. I will copy them here.

> Important: There's no guarantee that the immediate parent of a block is a vertical. We support all sorts of block structures on our platform - and especially those that are XML-defined by MIT.
> 
> For example, you may see:
> sequential -> vertical -> split_test -> problem
> OR
> sequential -> vertical -> vertical -> problem
> OR
> sequential -> vertical -> conditional_block -> problem

> Important: You'll want to add another 5th check here - check whether the problem is still accessible. The problem may become inaccessible after the learner attempted it in the past. Course teams change content accessibility even in live courses - especially using the "Hide Content" feature. Or, sometimes the learner changes enrollment tracks and they gain/lose access to content. See http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/developing_course/controlling_content_visibility.html
> 
> A way to satisfy this (pretty easily) is to
> (1) pass course_blocks (the return value of get_course_blocks) to this method,
> (2) check that the given block_key is a member of course_blocks.
> 
> This works because get_course_blocks automatically excludes all blocks that the learner doesn't have access to.